### PR TITLE
Slight improvements to the generated service file.

### DIFF
--- a/systemd.service.jst
+++ b/systemd.service.jst
@@ -30,11 +30,10 @@ LimitNOFILE=infinity
 # Allow core dumps for debugging
 LimitCORE=infinity
 
-# Assuming the service is a network accessible app
-After=network-online.target
-Wants=network-online.target
-
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog
 Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/test/fixtures/strong-pm.service
+++ b/test/fixtures/strong-pm.service
@@ -25,11 +25,10 @@ LimitNOFILE=infinity
 # Allow core dumps for debugging
 LimitCORE=infinity
 
-# Assuming the service is a network accessible app
-After=network-online.target
-Wants=network-online.target
-
 StandardInput=null
 StandardOutput=syslog
 StandardError=syslog
 Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Below are slight improvements to the systemd service file:

1) "A node app" was not very descriptive when running `systemctl status`, updated to be more descriptive to say "StrongLoop Process Manager".

2) Both `Wants` and `After` options are not valid inside the [Service] section and produce an error message when running the service. They could've been moved into the [Unit] section, but after reading the [systemd network target documentation](http://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/), I believe the options could be safely removed altogether. 

3) Added an [Install] section which allows the service to be enabled or disabled to run at boot time with `systemctl enable strong-pm` and `systemctl disable strong-pm`.

Thanks!
